### PR TITLE
fix: ensure filter is not cleared upon closing the side panel

### DIFF
--- a/src/components/top-nav/side-menu/drawer.jsx
+++ b/src/components/top-nav/side-menu/drawer.jsx
@@ -694,6 +694,7 @@ class SideMenuDrawer extends React.Component {
 					onBlur={ this.props.onFilterBlur }
 					onChange={ this._onFilterChange }
 					aria-controls="side-menu-list"
+					filter={ this.state.filter }
 				/>
 				<div className="side-menu-list-wrapper" >
 					<List

--- a/src/components/top-nav/side-menu/filter.jsx
+++ b/src/components/top-nav/side-menu/filter.jsx
@@ -37,6 +37,7 @@ class SideMenuFilter extends React.Component {
 	* @private
 	* @constructor
 	* @param {Object} props - component properties
+	* @param {string} props.filter - text the user has entered to filter the list of packages displayed in the side menu
 	* @param {Callback} props.onFocus - callback to invoke when the menu filter receives focus
 	* @param {Callback} props.onBlur - callback to invoke when the menu filter loses focus
 	* @param {Callback} props.onChange - callback to invoke upon a change in the filter
@@ -44,9 +45,6 @@ class SideMenuFilter extends React.Component {
 	*/
 	constructor( props ) {
 		super( props );
-		this.state = {
-			'filter': ''
-		};
 	}
 
 	/**
@@ -56,11 +54,7 @@ class SideMenuFilter extends React.Component {
 	* @param {Object} event - event object
 	*/
 	_onFilterChange = ( event ) => {
-		var filter = event.target.value;
-		this.props.onChange( filter );
-		this.setState({
-			'filter': filter
-		});
+		this.props.onChange( event.target.value );
 	}
 
 	/**
@@ -70,9 +64,6 @@ class SideMenuFilter extends React.Component {
 	* @param {Object} event - event object
 	*/
 	_onResetFilterClick = () => {
-		this.setState({
-			'filter': ''
-		});
 		this.props.onChange( '' );
 	}
 
@@ -91,12 +82,12 @@ class SideMenuFilter extends React.Component {
 					onChange={ this._onFilterChange }
 					onFocus={ this.props.onFocus }
 					onBlur={ this.props.onBlur }
-					value={ this.state.filter }
+					value={ this.props.filter }
 					placeholder="Type here to filter menu..."
 					title="Filter package menu"
 					aria-label="filter menu"
 				/>
-				{ this.state.filter
+				{ this.props.filter
 					? <ClearIcon
 						className="side-menu-filter-clear"
 						title="Clear the current filter"
@@ -119,6 +110,7 @@ class SideMenuFilter extends React.Component {
 * @type {Object}
 */
 SideMenuFilter.propTypes = {
+	'filter': PropTypes.string.isRequired,
 	'onFocus': PropTypes.func.isRequired,
 	'onBlur': PropTypes.func.isRequired,
 	'onChange': PropTypes.func.isRequired


### PR DESCRIPTION
Just passed down the filter prop from drawer to filter component.

Resolves #57.

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [x] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `master`.
-   [x] Submitted against `master` branch.

## Description

> What is the purpose of this pull request?

This PR fixes the issue of filter input clears upon closing and reopening side panel

[Screencast from 2024-03-22 13-57-19.webm](https://github.com/stdlib-js/www/assets/100030865/9b28130f-fd6c-477a-bd4f-72f330f573ec)

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #57 
-   fixes #

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/www/blob/master/LICENSE

<!-- </links> -->
