### PR TITLE
fix: ensure side panel closes on outside click on mobile device

### DIFF
--- a/public/css/docs/layout.css
+++ b/public/css/docs/layout.css
@@ -1418,6 +1418,17 @@ h2 {
 	margin: 12px;
 }
 
+@media screen and (max-width: 640px) {
+	.side-menu-head .icon-button.side-menu-close-button {
+		border: none;
+	}
+	.side-menu-head .icon-button.side-menu-close-button .icon {
+		width: 24px;
+		height: 24px;
+		margin: 0px;
+	}
+}
+
 .side-menu-wrapper {
 	width: 0;
 }

--- a/src/components/top-nav/side-menu/drawer.jsx
+++ b/src/components/top-nav/side-menu/drawer.jsx
@@ -798,12 +798,14 @@ class SideMenuDrawer extends React.Component {
 	* @returns {ReactElement} React element
 	*/
 	render() {
+		const isMobile = typeof window !== 'undefined' && window.innerWidth <= 640;
 		return (
 			<Drawer
 				className="side-menu-drawer"
-				variant="persistent"
+				variant={isMobile ? 'temporary' : 'persistent'}
 				anchor="left"
 				open={ this.props.open }
+				onClose={isMobile ? this._onMenuClose : undefined}
 				classes={{
 					paper: 'side-menu-drawer'
 				}}


### PR DESCRIPTION
Resolves #50 .

<!--lint disable first-heading-level-->

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read and understand the [Code of Conduct][code-of-conduct].
-   [x] Read and understood the [licensing terms][license].
-   [x] Searched for existing issues and pull requests **before** submitting this pull request.
-   [x] Filed an issue (or an issue already existed) **prior to** submitting this pull request.
-   [x] Rebased onto latest `master`.
-   [x] Submitted against `master` branch.

## Description

This PR enhances the `SideMenu` component to enure side panel closes on outside click on mobile device.

This pull request:

- Updates the `Drawer` component to switch between `persistent` and `temporary` variants based on screen width (`<= 640px` is considered mobile).
- Adds conditional `onClose` behavior: only triggers on mobile when the `Drawer` is temporary.
- Introduces mobile-specific CSS to adjust the close button’s styling at `max-width: 640px`.

## Related Issues

> Does this pull request have any related issues? yes

This pull request:

-   resolves #50
-   fixes #50

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

* * *

@stdlib-js/reviewers

<!-- <links> -->

[code-of-conduct]: https://github.com/stdlib-js/stdlib/blob/develop/CODE_OF_CONDUCT.md

[license]: https://github.com/stdlib-js/www/blob/master/LICENSE

<!-- </links> -->
